### PR TITLE
Use --no-interaction flag to prevent continue as root user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -745,7 +745,7 @@ install_pterodactyl() {
         curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
     fi
     cp .env.example .env
-    /usr/local/bin/composer install --no-dev --optimize-autoloader
+    /usr/local/bin/composer install --no-dev --optimize-autoloader --no-interaction
     php artisan key:generate --force
     php artisan p:environment:setup -n --author=$email --url=https://$FQDN --timezone=America/New_York --cache=redis --session=database --queue=redis --redis-host=127.0.0.1 --redis-pass= --redis-port=6379
     php artisan p:environment:database --host=127.0.0.1 --port=3306 --database=panel --username=pterodactyl --password=$password


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/Revenact/Pterodactyl-Script/blob/master/CONTRIBUTING.md) 
- [x] Tests have been made. 
- [x] [Readme](https://github.com/Revenact/Pterodactyl-Script/blob/master/README.md) have been updated (for bug fixes / features)
- [x] [Changelog](https://github.com/Revenact/Pterodactyl-Script/blob/master/CHANGELOG.md) has be updated, and a version made


* **What kind of change does this PR introduce?** (Bug fix, feature, OS support, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Every time we install a panel we have to enter `yes`


* **What is the new behavior (if this is a feature change)?**
Now we can skip enter `yes`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

https://getcomposer.org/doc/03-cli.md#global-options